### PR TITLE
feat: piano loads subset of audio notes in layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smplr",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smplr",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.25.2",

--- a/src/splendid-grand-piano/splendid-grand-piano.spec.ts
+++ b/src/splendid-grand-piano/splendid-grand-piano.spec.ts
@@ -1,0 +1,76 @@
+import { InternalPlayerMock, createAudioContextMock, createFetchMock } from "../test-helpers";
+import { SplendidGrandPiano } from "../splendid-grand-piano";
+
+function setup() {
+  createFetchMock({
+    "https://danigb.github.io/samples/splendid-grand-piano/PP-C3.ogg":
+      "PP-C3",
+    "https://danigb.github.io/samples/splendid-grand-piano/Mp-C3.ogg":
+      "Mp-C3",
+    "https://danigb.github.io/samples/splendid-grand-piano/Mf-C3.ogg":
+      "Mf-C3",
+    "https://danigb.github.io/samples/splendid-grand-piano/FF-C3.ogg":
+      "FF-C3",
+    "https://danigb.github.io/samples/splendid-grand-piano/FF-G3.ogg":
+      "FF-G3",
+  });
+  const mock = createAudioContextMock();
+  const context = mock.context;
+
+  return { context, mock };
+}  
+
+describe("Splendid grand piano", () => {
+  it("only specified notes are loaded", async () => {
+    const { context } = setup();
+    const piano = await new SplendidGrandPiano(context, {
+      notesToLoad: {
+        notes: [60, 67],
+        velocityRange: [105, 106]
+      }
+    }).load;
+
+    expect(Object.keys(piano.buffers)).toHaveLength(2);
+    expect(piano.buffers).toEqual({ 'FF60': { arrayBuffer: 'FF-C3' }, 'FF67': { arrayBuffer: 'FF-G3' } });
+
+    const start = jest.fn();
+
+    (piano as any).player.start = start;
+    piano.start({ note: 'C4', velocity: 105 });
+    expect(start).toHaveBeenCalledWith({ note: 'FF60', stopId: 60, detune: 0, velocity: 105 });
+  });
+
+  it("specified notes are loaded across multiple velocity ranges when given", async () => {
+    const { context } = setup();    
+    const piano = await new SplendidGrandPiano(context, {
+      notesToLoad: {
+        notes: [60],
+        velocityRange: [1, 109]
+      }
+    }).load;
+
+    expect(Object.keys(piano.buffers)).toHaveLength(5);
+    expect(piano.buffers).toEqual({ 
+        'FF60': { arrayBuffer: 'FF-C3' },
+        'MF60': { arrayBuffer: 'Mf-C3' },
+        'MP60': { arrayBuffer: 'Mp-C3' },
+        'PP60': { arrayBuffer: 'PP-C3' },
+        'PPP60': { arrayBuffer: 'PP-C3' }
+    });
+  });
+
+  it("detuning is based on loaded notes", async () => {
+    const { context } = setup();
+    const piano = await new SplendidGrandPiano(context, {
+      notesToLoad: {
+        notes: [60],
+        velocityRange: [105, 106]
+      }
+    }).load;
+    const start = jest.fn();
+
+    (piano as any).player.start = start;
+    piano.start({ note: 'C6', velocity: 105 });
+    expect(start).toHaveBeenCalledWith({ note: 'FF60', stopId: 84, detune: 2400, velocity: 105 });
+  });
+});


### PR DESCRIPTION
**Summary:**
I've introduced the ability for the Splended Grand Piano component to load a subset of its audio files in the configuration object.

**Why:**
This allows you to reduce the amount of audio files downloaded by the user by specifying the notes and a velocity range that the user will play when setting the piano component up.

**Changes:**
- added optional *notesToLoad* object to Splended Grand Piano's configuration object
- added filtering for velocity and sample layers based on *notesToLoad* data
- added unit tests for these changes  

  

**[Additional Note + Example]:**
`notesToLoad.velocityRange` will include the notes given in `notesToLoad.notes` for all velocity layers in that velocity range. 

So if a user wants to load audio files for the note C4 for all velocity layers, they can pass a notesToLoad object with this data. The resulting component would look like this

```js
import { SplendidGrandPiano } from "smplr";

const context = new AudioContext();
const piano = new SplendidGrandPiano(context, { 
     notesToLoad:  {
          notes: [60],
          velocityRange: [1, 127],
     }
});

piano.start({ note: "C4" });
```