### PR TITLE
fix: respect Soundfont 'kit' option and prevent console warning

### DIFF
--- a/src/soundfont/soundfont-instrument.ts
+++ b/src/soundfont/soundfont-instrument.ts
@@ -62,6 +62,7 @@ function base64ToArrayBuffer(base64: string) {
 }
 
 export const SOUNDFONT_KITS = ["MusyngKite", "FluidR3_GM"];
+export const DEFAULT_SOUNDFONT_KIT = SOUNDFONT_KITS[0];
 
 export const SOUNDFONT_INSTRUMENTS = [
   "accordion",

--- a/src/soundfont/soundfont.ts
+++ b/src/soundfont/soundfont.ts
@@ -9,6 +9,7 @@ import { HttpStorage, Storage } from "../storage";
 import {
   SOUNDFONT_INSTRUMENTS,
   SOUNDFONT_KITS,
+  DEFAULT_SOUNDFONT_KIT,
   gleitzKitUrl,
   soundfontInstrumentLoader,
 } from "./soundfont-instrument";
@@ -134,7 +135,7 @@ function getSoundfontConfig(options: SoundfontOptions): SoundfontConfig {
     throw Error("Soundfont: instrument or instrumentUrl is required");
   }
   const config = {
-    kit: "MusyngKite",
+    kit: options.kit ?? DEFAULT_SOUNDFONT_KIT,
     instrument: options.instrument,
     storage: options.storage ?? HttpStorage,
     // This is to compensate the low volume of the original samples
@@ -161,7 +162,7 @@ function getSoundfontConfig(options: SoundfontOptions): SoundfontConfig {
       );
     }
   } else {
-    if (config.kit || config.instrument) {
+    if (config.kit !== DEFAULT_SOUNDFONT_KIT || config.instrument) {
       console.warn(
         "Soundfont: 'kit' and 'instrument' config parameters are ignored because 'instrumentUrl' is explicitly set."
       );


### PR DESCRIPTION
The latest update was throwing a console warning about ``config.kit`` being set, even though I was using a custom `instrumentUrl` and hadn't set `config.kit` to anything. I also noticed that `config.kit` wasn't being properly passed to the soundfont options when I wanted to try out the FluidR3_GM kit.

This pull request fixes both issues:
1.  Making sure the `kit` option from the user is passed to the config (adding a constant for clarity)
2.  If the user is using a custom `instrumentUrl`, it will first check if`config.kit` is set to the default kit before throwing a console warning