### PR TITLE
feat: selective soundfont loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,15 @@ const marimba = Soundfont(context, {
 });
 ```
 
+If you want to limit which source sample notes are decoded and loaded into memory:
+
+```js
+const marimba = Soundfont(context, {
+  instrument: "marimba",
+  notesToLoad: ["C4", "E4", "G4"], // note names or MIDI numbers
+});
+```
+
 #### Soundfont sustained notes
 
 You can enable note looping to make note names indefinitely long by loading loop data:

--- a/src/soundfont/soundfont.test.ts
+++ b/src/soundfont/soundfont.test.ts
@@ -240,4 +240,51 @@ describe("Soundfont", () => {
     expect(sf.loadProgress).toHaveProperty("loaded");
     expect(sf.loadProgress).toHaveProperty("total");
   });
+
+  it("decodes all soundfont notes when notesToLoad is omitted", async () => {
+    const ctx = makeContext();
+    const sf = Soundfont(ctx as unknown as AudioContext, {
+      instrument: "marimba",
+    });
+    await sf.ready;
+
+    expect(ctx.decodeAudioData).toHaveBeenCalledTimes(2);
+    expect(sf.loadProgress).toEqual({ loaded: 2, total: 2 });
+  });
+
+  it("limits soundfont decoding if notesToLoad is specified", async () => {
+    const ctx = makeContext();
+    const sf = Soundfont(ctx as unknown as AudioContext, {
+      instrument: "marimba",
+      notesToLoad: ["C4"],
+    });
+    await sf.ready;
+
+    expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(sf.loadProgress).toEqual({ loaded: 1, total: 1 });
+  });
+
+  it("accepts MIDI numbers in notesToLoad", async () => {
+    const ctx = makeContext();
+    const sf = Soundfont(ctx as unknown as AudioContext, {
+      instrument: "marimba",
+      notesToLoad: [60],
+    });
+    await sf.ready;
+
+    expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(sf.loadProgress).toEqual({ loaded: 1, total: 1 });
+  });
+
+  it("ignores invalid notesToLoad entries", async () => {
+    const ctx = makeContext();
+    const sf = Soundfont(ctx as unknown as AudioContext, {
+      instrument: "marimba",
+      notesToLoad: ["not-a-note", 60],
+    });
+    await sf.ready;
+
+    expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(sf.loadProgress).toEqual({ loaded: 1, total: 1 });
+  });
 });

--- a/src/soundfont/soundfont.ts
+++ b/src/soundfont/soundfont.ts
@@ -31,6 +31,7 @@ type SoundfontConfig = {
   extraGain: number;
   loadLoopData: boolean;
   loopDataUrl?: string;
+  notesToLoad?: Array<string | number>;
 };
 
 export type SoundfontOptions = Partial<
@@ -41,6 +42,8 @@ export type SoundfontOptions = Partial<
     pan?: number;
     velocity?: number;
     onLoadProgress?: (progress: LoadProgress) => void;
+    /** Limit which source sample notes are decoded. Can be MIDI note numbers or note names. */
+    notesToLoad?: Array<string | number>;
   }
 >;
 
@@ -95,13 +98,15 @@ async function decodeSoundfontFile(
   ).text();
   const json = midiJsToJson(sourceFile);
 
-  const noteNames = Object.keys(json);
+  const selectedNotes = normalizeNotesToLoad(config.notesToLoad);
+  const noteNames = Object.keys(json).filter((noteName) => {
+    const midi = toMidi(noteName);
+    return midi !== undefined && (!selectedNotes || selectedNotes.has(midi));
+  });
   const buffers = new Map<string, AudioBuffer>();
 
   await Promise.all(
     noteNames.map(async (noteName) => {
-      const midi = toMidi(noteName);
-      if (midi === undefined) return;
       try {
         const audioData = base64ToArrayBuffer(
           removeBase64Prefix(json[noteName]),
@@ -117,7 +122,10 @@ async function decodeSoundfontFile(
     }),
   );
 
-  return { buffers, noteNames: [...buffers.keys()] };
+  return {
+    buffers,
+    noteNames: noteNames.filter((noteName) => buffers.has(noteName)),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -183,6 +191,7 @@ function getSoundfontConfig(options: SoundfontOptions): SoundfontConfig {
     loadLoopData: options.loadLoopData ?? false,
     loopDataUrl: options.loopDataUrl,
     instrumentUrl: options.instrumentUrl ?? "",
+    notesToLoad: options.notesToLoad,
   };
 
   if (config.instrument && config.instrument.startsWith("http")) {
@@ -217,6 +226,19 @@ function getSoundfontConfig(options: SoundfontOptions): SoundfontConfig {
   }
 
   return config;
+}
+
+/** Normalizes array of note names and/or MIDI note numbers to a set of MIDI note numbers. */
+function normalizeNotesToLoad(
+  notes: Array<string | number> | undefined,
+): Set<number> | undefined {
+  if (!notes) return undefined;
+  const midiNotes = new Set<number>();
+  for (const note of notes) {
+    const midi = toMidi(note);
+    if (midi !== undefined) midiNotes.add(midi);
+  }
+  return midiNotes;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
As briefly discussed in #108, this adds a way to limit which notes are decoded/loaded from a MIDI.js soundfont file. This helps to limit memory usage when playing a prepared MIDI file, for example.